### PR TITLE
An update to compiler test to hide expected error messages from appearing

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -3,6 +3,9 @@ package compiler
 import (
 	"io/ioutil"
 	"testing"
+	"log"
+	"bytes"
+	"os"
 )
 
 const EXPECTED_SIMPLE_COMPILE = `body {
@@ -13,7 +16,26 @@ func TestFindCompilable(t *testing.T) {
 	t.Parallel()
 
 	ctx := NewSassContext(NewSassCommand(), "../integration/bad-src", "../integration/out")
+
+	//The following line is expected to employ fileLogCompilationError which will use log to
+	//output an error.  By redirecting the output of log temporarily, we can both test that
+	//this error takes place and avoid outputing to stderr during a succesful test.
+
+	//Set up error buffer.
+	var buf bytes.Buffer
+    log.SetOutput(&buf)
+	
+	//do the actual call
 	compilable := findCompilable(ctx)
+	
+	//restore log output to its normal stderr
+	log.SetOutput(os.Stderr)
+    
+    //and finally make sure we did get the output error we expected.
+    if (len(buf.String()) == 0) {
+    	t.Error()
+    }
+	
 
 	if len(compilable) != 0 {
 		t.Error()

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -23,7 +23,7 @@ func TestFindCompilable(t *testing.T) {
 
 	//Set up error buffer.
 	var buf bytes.Buffer
-    log.SetOutput(&buf)
+	log.SetOutput(&buf)
 	
 	//do the actual call
 	compilable := findCompilable(ctx)
@@ -31,10 +31,10 @@ func TestFindCompilable(t *testing.T) {
 	//restore log output to its normal stderr
 	log.SetOutput(os.Stderr)
     
-    //and finally make sure we did get the output error we expected.
-    if (len(buf.String()) == 0) {
-    	t.Error()
-    }
+    	//and finally make sure we did get the output error we expected.
+    	if (len(buf.String()) == 0) {
+    		t.Error()
+    	}
 	
 
 	if len(compilable) != 0 {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -13,8 +13,6 @@ const EXPECTED_SIMPLE_COMPILE = `body {
 `
 
 func TestFindCompilable(t *testing.T) {
-	t.Parallel()
-
 	ctx := NewSassContext(NewSassCommand(), "../integration/bad-src", "../integration/out")
 
 	//The following line is expected to employ fileLogCompilationError which will use log to


### PR DESCRIPTION
By redirecting the output of log temporarily, we can both test that this error takes place and avoid outputing to stderr during a successful test.